### PR TITLE
Updating path for prod cryptomaterials

### DIFF
--- a/demo/cmdDocker.sh
+++ b/demo/cmdDocker.sh
@@ -11,7 +11,7 @@ then
     tar -zxf cryptoMaterial.tgz -C $CRYPTO_DIR cryptoMaterial/static/dev --strip-components=2
 else
     # copying production cryptomaterial:
-    tar -zxf cryptoMaterial.tgz -C $CRYPTO_DIR cryptoMaterial/static/prod --strip-components=3
+    tar -zxf cryptoMaterial.tgz -C $CRYPTO_DIR cryptoMaterial/static/prod --strip-components=2
 fi
 
 SSL_KEY_STORE="verification-service-keystore.p12"

--- a/src/main/java/org/fidoalliance/fdo/epid/verification/conf/ProdStaticResourcesConf.java
+++ b/src/main/java/org/fidoalliance/fdo/epid/verification/conf/ProdStaticResourcesConf.java
@@ -19,7 +19,7 @@ public class ProdStaticResourcesConf implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    String resourceLocation = "file:" + cryptoMaterialPath + "/static/";
+    String resourceLocation = "file:" + cryptoMaterialPath + "/static/prod/";
     registry
         .addResourceHandler(
             "/**/" + EpidResource.PRIVRL.toLowerCaseString(),

--- a/src/main/java/org/fidoalliance/fdo/epid/verification/services/staticresources/EpidStaticResourceLoader.java
+++ b/src/main/java/org/fidoalliance/fdo/epid/verification/services/staticresources/EpidStaticResourceLoader.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class EpidStaticResourceLoader {
 
-  private static final String PRODUCTION_DIR = "";
+  private static final String PRODUCTION_DIR = "/prod";
   private static final String DEVELOPMENT_DIR = "/dev";
 
   private final String cryptoMaterialPath;

--- a/src/test/java/org/fidoalliance/fdo/epid/verification/utils/EpidStaticResourceLoaderTest.java
+++ b/src/test/java/org/fidoalliance/fdo/epid/verification/utils/EpidStaticResourceLoaderTest.java
@@ -49,7 +49,7 @@ public class EpidStaticResourceLoaderTest {
 
   @Test
   public void testGetSigrlEpid11ProductionPositive() throws Exception {
-    String epid11Group5SigrlDevPath = "file:cryptoMaterialPath/static/epid11/00000005/sigrl";
+    String epid11Group5SigrlDevPath = "file:cryptoMaterialPath/static/prod/epid11/00000005/sigrl";
     Mockito.when(resourceLoader.getResource(epid11Group5SigrlDevPath))
         .thenReturn(new ByteArrayResource(EPID11_GROUP5_SIGRL));
     Mockito.when(environment.getActiveProfiles()).thenReturn(new String[] {"production"});


### PR DESCRIPTION
Updating path for prod cryptomaterials to be consumed by the service.
This done to ensure the path remains uniform for dev & prod modes of
service deployment.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>