### PR TITLE
Upgrading Log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <spring-boot-starter-jetty.version>2.4.9</spring-boot-starter-jetty.version>
     <spring-boot-starter-validation.version>2.4.9</spring-boot-starter-validation.version>
     <testng.version>7.4.0</testng.version>
+    <log4j2.version>2.15.0</log4j2.version>
 
     <!-- Maven Dependency -->
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>


### PR DESCRIPTION
  Upgrading Log4j version to 2.15.0 from 2.14.1

  CVE-2021-44228 was issued for Log4j 2.14.1 component.

Signed-off-by: Davis Benny <davis.benny@intel.com>