### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,12 @@
     <powermock-api-mockito2.version>2.0.9</powermock-api-mockito2.version>
     <powermock-module-testng.version>2.0.9</powermock-module-testng.version>
     <spring-aspects.version>5.3.8</spring-aspects.version>
-    <spring-boot-maven-plugin.version>2.4.9</spring-boot-maven-plugin.version>
-    <spring-boot-starter-data-rest.version>2.4.9</spring-boot-starter-data-rest.version>
-    <spring-boot-starter-jetty.version>2.4.9</spring-boot-starter-jetty.version>
-    <spring-boot-starter-validation.version>2.4.9</spring-boot-starter-validation.version>
+    <spring-boot-maven-plugin.version>2.5.7</spring-boot-maven-plugin.version>
+    <spring-boot-starter-data-rest.version>2.5.7</spring-boot-starter-data-rest.version>
+    <spring-boot-starter-jetty.version>2.5.7</spring-boot-starter-jetty.version>
+    <spring-boot-starter-validation.version>2.5.7</spring-boot-starter-validation.version>
     <testng.version>7.4.0</testng.version>
+    <log4j2.version>2.16.0</log4j2.version>
 
     <!-- Maven Dependency -->
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
@@ -57,7 +58,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.4.9</version>
+    <version>2.5.7</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Upgrading dependencies to the latest version

   org.springframework.boot:spring.*  ==> 2.5.7
   log4j => 2.16.0

Signed-off-by: Davis Benny <davis.benny@intel.com>