### PR TITLE
Upgrading log4j from 2.16.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <spring-boot-starter-jetty.version>2.5.7</spring-boot-starter-jetty.version>
     <spring-boot-starter-validation.version>2.5.7</spring-boot-starter-validation.version>
     <testng.version>7.4.0</testng.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
 
     <!-- Maven Dependency -->
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>


### PR DESCRIPTION
  Upgrading log4j from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>