### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
     <bcpkix-jdk15on.version>1.69</bcpkix-jdk15on.version>
     <bcprov-jdk15on.version>1.69</bcprov-jdk15on.version>
     <guava.version>30.1.1-jre</guava.version>
-    <jackson-annotations.version>2.12.3</jackson-annotations.version>
-    <jackson-core.version>2.12.3</jackson-core.version>
-    <jackson-databind.version>2.12.3</jackson-databind.version>
+    <jackson-annotations.version>2.12.6</jackson-annotations.version>
+    <jackson-core.version>2.12.6</jackson-core.version>
+    <jackson-databind.version>2.12.6</jackson-databind.version>
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -37,12 +37,12 @@
     <powermock-api-mockito2.version>2.0.9</powermock-api-mockito2.version>
     <powermock-module-testng.version>2.0.9</powermock-module-testng.version>
     <spring-aspects.version>5.3.8</spring-aspects.version>
-    <spring-boot-maven-plugin.version>2.5.7</spring-boot-maven-plugin.version>
-    <spring-boot-starter-data-rest.version>2.5.7</spring-boot-starter-data-rest.version>
-    <spring-boot-starter-jetty.version>2.5.7</spring-boot-starter-jetty.version>
-    <spring-boot-starter-validation.version>2.5.7</spring-boot-starter-validation.version>
+    <spring-boot-maven-plugin.version>2.5.8</spring-boot-maven-plugin.version>
+    <spring-boot-starter-data-rest.version>2.5.8</spring-boot-starter-data-rest.version>
+    <spring-boot-starter-jetty.version>2.5.8</spring-boot-starter-jetty.version>
+    <spring-boot-starter-validation.version>2.5.8</spring-boot-starter-validation.version>
     <testng.version>7.4.0</testng.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
 
     <!-- Maven Dependency -->
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
@@ -58,7 +58,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.7</version>
+    <version>2.5.8</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
   org.springframework.boot:spring.*  ==> 2.5.8
   log4j => 2.17.1
   jackson ==> 2.12.6

Signed-off-by: Davis Benny <davis.benny@intel.com>