### PR TITLE
Updating Docker network mode to support Ubuntu 22

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -28,6 +28,5 @@ services:
     mem_reservation: 1000m
     cpu_shares: 5
     pids_limit: 100
-    network_mode: host
 volumes:
   fdo-m2:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -16,7 +16,6 @@ services:
             context: .
             dockerfile: Dockerfile-epid-verification
         restart: on-failure:5
-        network_mode: host
         healthcheck:
             test: wget --spider -Y off http://localhost:1180/health || exit 1 
             interval: 1m


### PR DESCRIPTION
  Updating Docker network mode to support Ubuntu 22.

Signed-off-by: Davis Benny <davis.benny@intel.com>