### PR TITLE
Adding spring.mvc.pathmatch.matching-strategy property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ server.connection-timeout: 70000
 # Available spring profiles are: development | production
 spring.profiles.active: development
 spring.main.allow-bean-definition-overriding: true
-
+spring.mvc.pathmatch.matching-strategy: ant_path_matcher
 
 logging.level.org.fidoalliance.fdo: DEBUG
 logging.level.org.springframework.web.servlet.resource: TRACE


### PR DESCRIPTION
  Adding spring.mvc.pathmatch.matching-strategy to
  application.properties file.

Signed-off-by: Davis Benny <davis.benny@intel.com>